### PR TITLE
refactor(Sales): moved sales endpoint mapping in SalesModule

### DIFF
--- a/src/BrewUp.Rest/Modules/SalesModule.cs
+++ b/src/BrewUp.Rest/Modules/SalesModule.cs
@@ -17,19 +17,6 @@ public sealed class SalesModule : IModule
 
     public IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        var group = endpoints.MapGroup("/v1/sales/")
-            .WithTags("Sales");
-        
-        group.MapPost("/", SalesEndpoints.HandleCreateOrder)
-            .Produces(StatusCodes.Status400BadRequest)
-            .Produces(StatusCodes.Status201Created)
-            .WithName("CreateSalesOrder");
-        
-        group.MapGet("/", SalesEndpoints.HandleGetOrders)
-            .Produces(StatusCodes.Status400BadRequest)
-            .Produces(StatusCodes.Status200OK)
-            .WithName("GetSalesOrders");
-        
-        return endpoints;
+        return endpoints.MapSalesEndpoints();
     }
 }

--- a/src/Sales/BrewUp.Sales.Facade/Endpoints/SalesEndpoints.cs
+++ b/src/Sales/BrewUp.Sales.Facade/Endpoints/SalesEndpoints.cs
@@ -1,12 +1,31 @@
 ﻿using BrewUp.Sales.Facade.Validators;
 using BrewUp.Shared.Contracts;
 using FluentValidation;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 
 namespace BrewUp.Sales.Facade.Endpoints;
 
 public static class SalesEndpoints
 {
+    public static IEndpointRouteBuilder MapSalesEndpoints(this IEndpointRouteBuilder endpoints) {
+        var group = endpoints.MapGroup("/v1/sales/")
+            .WithTags("Sales");
+
+        group.MapPost("/", SalesEndpoints.HandleCreateOrder)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status201Created)
+            .WithName("CreateSalesOrder");
+
+        group.MapGet("/", SalesEndpoints.HandleGetOrders)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status200OK)
+            .WithName("GetSalesOrders");
+
+        return endpoints;
+    }
+
     public static async Task<IResult> HandleCreateOrder(
         ISalesFacade salesFacade,
         IValidator<SalesOrderJson> validator,


### PR DESCRIPTION
In this way the injection of the module endpoints is decided by the module itself and it allows, in the future:

* to change the endpoints without modification outside the module itself
* to change the method (for example using an event-based technology) without editing the Rest project

In this way it should be fully decoupled.